### PR TITLE
Allow user specified logging instance

### DIFF
--- a/examples/sensor.py
+++ b/examples/sensor.py
@@ -3,6 +3,12 @@ import argparse
 import RPi.GPIO as GPIO
 from pi_sht1x import SHT1x
 
+import logging
+import sys
+
+logger = logging.getLogger()
+logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
+
 
 class Choices(list):
     def __contains__(self, item):
@@ -28,11 +34,15 @@ def main():
     parser.add_argument('-o', '--otp-no-reload', action='store_true',
                         help='Used to enable OTP no reload, will save about 10ms per measurement.')
     parser.add_argument('-c', '--no-crc-check', action='store_false', help='Performs CRC checking.')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug logging.')
     args = parser.parse_args()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
 
     mode = GPIO.BCM if args.gpio_mode.upper() == 'BCM' else GPIO.BOARD
     with SHT1x(args.data_pin, args.sck_pin, gpio_mode=mode, vdd=args.vdd, resolution=args.resolution,
-               heater=args.heater, otp_no_reload=args.otp_no_reload, crc_check=args.no_crc_check) as sensor:
+               heater=args.heater, otp_no_reload=args.otp_no_reload, crc_check=args.no_crc_check, logger=logger) as sensor:
         for i in range(5):
             temp = sensor.read_temperature()
             humidity = sensor.read_humidity(temp)

--- a/pi_sht1x/sht1x.py
+++ b/pi_sht1x/sht1x.py
@@ -57,7 +57,7 @@ class SHT1x:
     VDD = {'5V': 5, '4V': 4, '3.5V': 3.5, '3V': 3, '2.5V': 2.5}
 
     def __init__(self, data_pin, sck_pin, gpio_mode=GPIO.BOARD, vdd='3.5V', resolution='High',
-                 heater=False, otp_no_reload=False, crc_check=True):
+                 heater=False, otp_no_reload=False, crc_check=True, logger=None):
         self.data_pin = data_pin
         self.sck_pin = sck_pin
         self.gpio_mode = gpio_mode
@@ -72,7 +72,7 @@ class SHT1x:
         self.temperature_fahrenheit = None
         self.humidity = None
         self.dew_point = None
-        self._logger = None
+        self._logger = logger
 
         GPIO.setmode(self.gpio_mode)
         self.initialize_sensor()


### PR DESCRIPTION
Currently, the logger writes debugging messages to a global log file by default. Since RPi.GPIO no longer requires root, this was throwing permission denied errors.

This patch allows the user to pass their own logger instance when instantiating the class, so logging can be disabled or directed to their own file or stdout.
