### PR TITLE
Fix missing comma in setup.py keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     classifiers=classifiers,
     keywords=[
         'sht', 'sensor', 'sht1x', 'sensirion', 'T', 'temperature', 'humidity', 'RH',
-        'dew point', 'celsius', 'measurement', 'gpio', 'serial', '2-wire', 'crc', 'crc-8'
+        'dew point', 'celsius', 'measurement', 'gpio', 'serial', '2-wire', 'crc', 'crc-8',
         'hardware', 'driver', 'ic'
     ]
 )


### PR DESCRIPTION
Seem to be a minor typo, merging 'crc-8' and 'hardware' into 'crc-8hardware'.